### PR TITLE
Add script to prioritize open issues by title keywords

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,17 @@
+# scripts/prioritize_issues.py
+
+Небольшой скрипт для быстрого ранжирования открытых issue по ключевым словам в заголовках.
+
+Использование:
+
+```bash
+python3 scripts/prioritize_issues.py --token $GITHUB_TOKEN --top 10
+```
+
+Параметры:
+- `--token` — GitHub token (если не задан, возьмётся из `GITHUB_TOKEN`)
+- `--owner` — владелец репозитория (по умолчанию `miamok`)
+- `--repo` — имя репозитория (по умолчанию `skills-integrate-mcp-with-copilot`)
+- `--top` — сколько показать сверху (по умолчанию 5)
+
+Скрипт не делает никаких изменений в репозитории — только читает открытые issues через GitHub API и выводит топ по простой эвристике.

--- a/scripts/prioritize_issues.py
+++ b/scripts/prioritize_issues.py
@@ -1,0 +1,63 @@
+IyEvdXNyL2Jpbi9lbnYgcHl0aG9uMwoiIiJCeS1za2lsaW5nIHNjcmlwdCB0byBhc2Npc3QgdG9wIG9wZW4gaXNzdWVzIGJ5IHRpdGxlIGtleXdvcmRzLgoKVXNhZ2U6CnB5dGhvbiBzY3JpcHRzL3ByaW9yaXppdGVfaXNzdWVzLnB5IC0tVG9LRU4gPEdIVUJfVE9LRU4+IC0tdG9wIDUKIiIiCmltcG9ydCByZXF1ZXN0cwppbXBvcnQgYXJnZXBhcnNlCmZyb21fYXRhcyA9IFsnc2VjdXJpdHknLCAnY3JpdGljYWwnLCAnYnVnJ10KCmtleV9zY29yZXMgPSB7CiAgICdzZWN1cml0eSc6IDUsCiAgICdjcml0aWNhbCc6IDUsCiAgICdidWcnOiA1LAogICAgJ2Vycm9yJzogMywKICAgICdmaXgnOiAzLAogICAgJ3Vyd2VyJzogNQp9CgoKZGVmIHNjb3Jl_title(title):
+    t = title.lower()
+    score = 0
+    for k, v in key_scores.items():
+        if k in t:
+            score += v
+    # small bonus for longer titles (more specific)
+    score += min(len(t.split()), 6) * 0.1
+    return score
+
+
+def fetch_issues(owner, repo, token=None):
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues"
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token:
+        headers['Authorization'] = f"token {token}"
+    params = {"state": "open", "per_page": 100, "page": 1}
+    issues = []
+    while True:
+        r = requests.get(url, headers=headers, params=params)
+        r.raise_for_status()
+        page_items = r.json()
+        if not page_items:
+            break
+        issues.extend(page_items)
+        if 'next' not in r.links:
+            break
+        params['page'] += 1
+    return issues
+
+
+def main():
+    p = argparse.ArgumentParser(description='Prioritize open issues by title keywords')
+    p.add_argument('--token', '-t', help='GitHub token (or set GITHUB_TOKEN)')
+    p.add_argument('--owner', default='miamok')
+    p.add_argument('--repo', default='skills-integrate-mcp-with-copilot')
+    p.add_argument('--top', type=int, default=5)
+    args = p.parse_args()
+
+    token = args.token or os.environ.get('GITHUB_TOKEN')
+
+    issues = fetch_issues(args.owner, args.repo, token)
+    scored = []
+    for it in issues:
+        # skip PRs
+        if 'pull_request' in it:
+            continue
+        title = it.get('title', '')
+        score = score_title(title)
+        scored.append((score, it))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+
+    print(f"Top {args.top} open issues for {args.owner}/{args.repo}:\n")
+    for s, it in scored[:args.top]:
+        num = it.get('number')
+        title = it.get('title')
+        url = it.get('html_url')
+        print(f"#{num} ({s:.2f}) - {title}\n  {url}\n")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Добавляет скрипт `scripts/prioritize_issues.py` и `scripts/README.md` для быстрого ранжирования открытых issue по ключевым словам в заголовках.

Использование:
```
python3 scripts/prioritize_issues.py --token $GITHUB_TOKEN --top 10
```

Скрипт читает открытые issues через GitHub API и выводит топ по простой эвристике. Не вносит изменений в репозиторий.